### PR TITLE
fix: add case statement for setting sssd capabilities based on Fedora version

### DIFF
--- a/1_prune.sh
+++ b/1_prune.sh
@@ -2,7 +2,7 @@
 # Prune files in tree that are extraneous
 
 get_fedora_version() {
-    cat /etc/os-release | grep --word-regexp VERSION_ID | cut --delimiter='=' --fields=2
+    cat ${TREE}/etc/os-release | grep --word-regexp VERSION_ID | cut --delimiter='=' --fields=2
 }
 
 if [ $(id -u) -ne 0 ]; then

--- a/1_prune.sh
+++ b/1_prune.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 # Prune files in tree that are extraneous
 
-get_fedora_version() {
-    cat ${TREE}/etc/os-release | grep --word-regexp VERSION_ID | cut --delimiter='=' --fields=2
-}
-
 if [ $(id -u) -ne 0 ]; then
     echo "Run as superuser"
     exit 1
@@ -200,44 +196,17 @@ setcap cap_net_bind_service=ep ./usr/bin/rcp
 setcap cap_net_bind_service=ep ./usr/bin/rlogin
 setcap cap_net_bind_service=ep ./usr/bin/rsh
 setcap cap_sys_admin=p $(realpath ./usr/bin/sunshine)
-# SSSD
-fedora_version="$(get_fedora_version)"
-set_sssd_caps='false' # defaulting to false for safety
-echo "Detected Fedora version: $fedora_version"
-case $fedora_version in
-    40)
-	echo 'Not setting capabilities on sssd binaries.'
-	set_sssd_caps='false'
-	;;
-    41)
-        # sssd version is 2.10.1+
-        sssd_krb5_child_caps='cap_dac_read_search,cap_setgid,cap_setuid=p'
-        sssd_ldap_child_caps='cap_dac_read_search=p'
-        sssd_selinux_child_caps='cap_setgid,cap_setuid=p'
-        sssd_pam_caps='cap_dac_read_search=p'
-	set_sssd_caps='true'
-        ;;
-    *)
-	# treat this as a default which "should" work in the future assuming the capabilities of Fedora 41's sssd binaries if the version is 41+
-	if [ $fedora_version -ge 41 ]; then
-	    echo "[WARNING] Unknown Fedora version: ${fedora_version}. Assuming capabilities."
-	    echo "[WARNING] Please confirm capabilities and add a case for this Fedora version in ${0}."
-            sssd_krb5_child_caps='cap_dac_read_search,cap_setgid,cap_setuid=p'
-            sssd_ldap_child_caps='cap_dac_read_search=p'
-            sssd_selinux_child_caps='cap_setgid,cap_setuid=p'
-            sssd_pam_caps='cap_dac_read_search=p'
-            set_sssd_caps='true'
-	else
-	    set_sssd_caps='false'
-	fi
-	;;
-esac
 
-if [ "$set_sssd_caps" == 'true' ]; then
-    setcap $sssd_krb5_child_caps ./usr/libexec/sssd/krb5_child
-    setcap $sssd_ldap_child_caps ./usr/libexec/sssd/ldap_child
-    setcap $sssd_selinux_child_caps ./usr/libexec/sssd/selinux_child
-    setcap $sssd_pam_caps ./usr/libexec/sssd/sssd_pam
+# SSSD
+if  [ -f ${TREE}/etc/os-release ] &&
+    [ $(cat ${TREE}/etc/os-release | grep VERSION_ID | grep 40) ]; then
+    echo "Detected Fedora version: 40"
+    echo "Not setting capabilities on sssd binaries for Fedora 40."
+else
+    setcap cap_dac_read_search,cap_setgid,cap_setuid=p ./usr/libexec/sssd/krb5_child
+    setcap cap_dac_read_search=p ./usr/libexec/sssd/ldap_child
+    setcap cap_setgid,cap_setuid=p ./usr/libexec/sssd/selinux_child
+    setcap cap_dac_read_search=p ./usr/libexec/sssd/sssd_pam
 fi
 
 # Fix polkid group


### PR DESCRIPTION
To fix https://github.com/ublue-os/bazzite/issues/2030 without breaking previous SSSD versions capabilities.

I'm not sure if there's a better place to put functions, but that could certainly be changed. I created a function in case the version comparison functionality might be useful for other packages in the future.

Tested locally on my machine, but tough for me to test running in the pipelines.