### PR TITLE
fix: correct Fedora 40 detection, and be more verbose about version

### DIFF
--- a/1_prune.sh
+++ b/1_prune.sh
@@ -198,11 +198,13 @@ setcap cap_net_bind_service=ep ./usr/bin/rsh
 setcap cap_sys_admin=p $(realpath ./usr/bin/sunshine)
 
 # SSSD
-if  [ -f ${TREE}/etc/os-release ] &&
-    [ $(cat ${TREE}/etc/os-release | grep VERSION_ID | grep 40) ]; then
-    echo "Detected Fedora version: 40"
-    echo "Not setting capabilities on sssd binaries for Fedora 40."
+if  [ -f ${TREE}/usr/etc/os-release ] && \
+    [ $(cat ${TREE}/usr/etc/os-release | grep VERSION_ID | grep 40) ]; then
+    echo "Detected Fedora version 40."
+    echo "NOT setting capabilities on sssd binaries."
 else
+    echo "Detected Fedora version 41 or higher."
+    echo "Setting latest capabilities on sssd binaries."
     setcap cap_dac_read_search,cap_setgid,cap_setuid=p ./usr/libexec/sssd/krb5_child
     setcap cap_dac_read_search=p ./usr/libexec/sssd/ldap_child
     setcap cap_setgid,cap_setuid=p ./usr/libexec/sssd/selinux_child


### PR DESCRIPTION

The below snippet from ```1_prune.sh```:
```
# Merge /usr/etc to /etc
# OSTree will error out if both dirs exist
# And rpm-ostree will be confused and use only one of them
if [ -d ./usr/etc ]; then
    echo
    echo WARNING: FOUND /usr/etc. MERGING TO ETC FOR COMPATIBILITY
    echo EXPECT PERMISSIONS ISSUES ON THE MERGED PATHS
    echo The following files from /usr/etc will be merged to /etc:
    tree ./usr/etc

    echo
    $RSYNC ./usr/etc/ ./etc
    rm -rf ./usr/etc
fi

# Move /etc to /usr/etc
mv ./etc ./usr/
```
seems to tell me that there *is* no ```/etc/os-release```, only a ```/usr/etc/os-release```, which means Fedora 40 images have been getting "detected" as "Fedora 40".

I've also added some output for when Fedora 41+ gets detected.