### PR TITLE
chore: add dedicated 1password layer

### DIFF
--- a/src/rechunk/meta.yml
+++ b/src/rechunk/meta.yml
@@ -245,7 +245,7 @@ meta:
       - sddm-breeze*
       - libkworkspace*
       - sddm-wayland*
-  
+
   #
   # Gnome
   #
@@ -771,3 +771,6 @@ meta:
   emacs:
     packages:
       - emacs*
+  1password:
+    packages:
+      - 1password*


### PR DESCRIPTION
1password has _many_ large files - totaling just over 500MB.  Splitting it into a dedicated layer will significantly improve updates for those who choose to layer this in custom images since this layer will not need to be redownloaded each update.

```
 INFO     Large remaining files:                                                 
          - 202.888 MB /usr/lib/1Password/1password                             
          - 144.866 MB /usr/lib/1Password/resources/app.asar.unpacked/index.node
          - 97.935 MB /usr/share/rpm/rpmdb.sqlite                               
          - 68.256 MB /usr/bin/cloud-provider-kind                              
          - 56.187 MB /usr/lib/1Password/1Password-LastPass-Exporter            
          - 54.850 MB /usr/lib/1Password/1Password-BrowserSupport               
          - 32.886 MB /usr/lib/1Password/resources/app.asar                     
          - 31.930 MB /usr/lib/1Password/1Password-Crash-Handler                
          - 18.429 MB /usr/lib/1Password/op-ssh-sign                            
          - 15.560 MB /usr/bin/twingated                                        
          - 15.271 MB /usr/lib/1Password/LICENSES.chromium.html                 
          - 13.750 MB /usr/etc/udev/hwdb.bin                                    
          - 11.840 MB /usr/lib/modules/6.16.8-200.fc42.x86_64/System.map        
          - 11.056 MB /usr/bin/kind                                             
          - 10.468 MB /usr/lib/1Password/icudtl.dat                             
          -  6.511 MB /usr/lib/1Password/libGLESv2.so                           
          -  6.223 MB /usr/lib/1Password/resources.pak                          
          -  4.793 MB /usr/lib/1Password/libvk_swiftshader.so                   
          -  3.877 MB /usr/etc/selinux/targeted/active/policy.kern              
          -  3.877 MB /usr/etc/selinux/targeted/active/policy.linked            
          -  3.877 MB /usr/etc/selinux/targeted/policy/policy.34                
          -  3.299 MB /usr/lib/firmware/intel-ucode/06-ad-01                    
          -  3.081 MB /usr/bin/yt-dlp                                           
          -  2.779 MB /usr/lib/1Password/libffmpeg.so                           
          -  2.298 MB /usr/lib/1Password/libvulkan.so.1                         
          -  1.573 MB /usr/lib/1Password/chrome_crashpad_handler                
          -  1.542 MB /usr/lib/firmware/intel-ucode/06-af-03                    
          -  1.540 MB /usr/lib/1Password/locales/ml.pak                         
          -  1.531 MB /usr/lib/1Password/locales/ta.pak                         
          -  1.487 MB /usr/lib/1Password/locales/kn.pak                         
          -  1.459 MB /usr/share/fonts/monaspace/Monaspace Radon Var.ttf        
          -  1.414 MB /usr/lib/1Password/locales/te.pak                         
          -  1.390 MB /usr/lib/modules/6.16.8-200.fc42.x86_64/modules.alias     
          -  1.375 MB /usr/lib/1Password/locales/hi.pak                         
          -  1.349 MB /usr/lib/modules/6.16.8-200.fc42.x86_64/modules.alias.bin 
          -  1.317 MB /usr/lib/1Password/locales/bn.pak                         
          -  1.300 MB /usr/lib/1Password/locales/gu.pak                         
          -  1.272 MB /usr/lib/1Password/locales/mr.pak                         
          -  1.217 MB /usr/lib/firmware/intel-ucode/06-8f-08                    
          -  1.197 MB                                                           
         /usr/lib/fontconfig/cache/f78d1c9a0a792df07abeab8c5e933cc8-le64.cache-9
          -  1.187 MB /usr/lib/1Password/locales/th.pak                         
          -  1.120 MB /usr/lib/1Password/locales/el.pak                         
          -  1.045 MB /usr/lib/1Password/locales/uk.pak                         
          -  1.043 MB /usr/lib/1Password/locales/ru.pak                         
          -  1.020 MB /usr/lib/1Password/locales/bg.pak                         
          -  0.990 MB /usr/share/fonts/monaspace/Monaspace Xenon Var.ttf        
          -  0.990 MB /usr/lib/1Password/locales/ar.pak                         
          -  0.966 MB /usr/share/fonts/monaspace/Monaspace Argon Var.ttf        
          -  0.964 MB /usr/lib/1Password/locales/sr.pak                         
          -  0.949 MB /usr/lib/bootupd/updates/EFI/fedora/shimx64.efi 
```

The glob pattern should match 1password and 1password-cli.

```
❯ rpm -qa | grep 1pass  
1password-cli-2.32.0-3.x86_64
1password-8.11.10-1.x86_64
```